### PR TITLE
Separate vision loop into separate process using CameraServer framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Contributing
 4. Push to the branch (`git push -u origin my-new-feature`)
 5. Create new Pull Request on github
 
+# Running the vision loop on a PC
+```bash
+python3 -m cscore vision.py:loop
+```

--- a/automations/manipulategear.py
+++ b/automations/manipulategear.py
@@ -63,6 +63,4 @@ class ManipulateGear(StateMachine):
 
     def put_dashboard(self):
         """Update all the variables on the smart dashboard"""
-        self.sd.putNumber("vision_x", self.vision.x)
-        self.sd.putNumber("smoothed_vision_x", self.vision.smoothed_x)
         self.sd.putNumber("vision_y", self.range_finder.getDistance())

--- a/components/vision.py
+++ b/components/vision.py
@@ -1,12 +1,10 @@
 import multiprocessing.sharedctypes
 
-import numpy as np
-import cv2
 import hal
 
 from magicbot import tunable
 
-MIN_MASKED_RATIO = 0.1
+from vision import vision_loop
 
 
 class Vision:
@@ -46,69 +44,3 @@ class Vision:
     @property
     def time(self):
         return self._data_array[1]
-
-
-def vision_loop(data_array):
-    import cscore as cs
-
-    width = 320
-    height = 240
-    fps = 25
-    videomode = cs.VideoMode.PixelFormat.kMJPEG, width, height, fps
-
-    camera = cs.UsbCamera("usbcam", 0)
-    camera.setVideoMode(*videomode)
-
-    camMjpegServer = cs.MjpegServer("httpserver", 8082)
-    camMjpegServer.setSource(camera)
-
-    cvsink = cs.CvSink("cvsink")
-    cvsink.setSource(camera)
-
-    cvSource = cs.CvSource("cvsource", *videomode)
-    cvmjpegServer = cs.MjpegServer("cvhttpserver", 8083)
-    cvmjpegServer.setSource(cvSource)
-
-    #Setting the exposure.
-    camera.setExposureManual(0)
-
-    # Images are big. Preallocate an array to fill the image with.
-    frame = np.zeros(shape=(height, width, 3), dtype=np.uint8)
-
-    while True:
-        time, frame = cvsink.grabFrame(frame)
-        if time == 0:
-            # We got an error; report it through the output stream.
-            cvSource.notifyError(cvsink.getError())
-        else:
-            x, img, masked_ratio = find_target(frame)
-            if masked_ratio > MIN_MASKED_RATIO:
-                loc = int((x+1) * width // 2)
-                cv2.line(img, (loc, 60), (loc, 180), (255, 255, 0), thickness=2, lineType=8, shift=0)
-                data_array[0] = x
-                data_array[1] = time
-            cvSource.putFrame(img)
-
-def find_target(img, lower=np.array([110/2, 200, 75]), upper=np.array([155/2, 255, 255])):
-
-    #Converting from RGB to HSV.
-    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
-
-    #Making the mask.
-    mask = cv2.inRange(hsv, lower, upper)
-
-    #Combining the mask with the frame
-    res = cv2.bitwise_and(img, img, mask=mask)
-
-    height, width = mask.shape
-    masked_pixels = mask.sum()
-    masked_ratio = masked_pixels / (height*width)
-
-    if masked_ratio > MIN_MASKED_RATIO:
-        X, Y = np.meshgrid(range(0, width), range(0, height))
-        x_coord = int((X * mask).sum() / masked_pixels)
-    else:
-        return None, res, masked_ratio
-
-    pos = 2 * x_coord / width - 1
-    return pos, res, masked_ratio

--- a/components/vision.py
+++ b/components/vision.py
@@ -89,7 +89,7 @@ def vision_loop(data_array):
                 data_array[1] = time
             cvSource.putFrame(img)
 
-def find_target(img, lower=np.array([110/2, 50, 50]), upper=np.array([155/2, 255, 255])):
+def find_target(img, lower=np.array([110/2, 200, 75]), upper=np.array([155/2, 255, 255])):
 
     #Converting from RGB to HSV.
     hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ wpilib>=2017.0.0
 robotpy-hal-sim>=2017.0.0
 pynetconsole>=1.1.0
 robotpy-ctre>=2017.0.0
-robotpy-wpilib-utilities>=2017.0.0
+robotpy-wpilib-utilities>=2017.0.4
 
 coverage
 python-coveralls

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+import vision
+
+
+def test_black():
+    res = vision.find_target(np.zeros(shape=(320, 240, 3), dtype=np.uint8))
+    assert res[0] is None

--- a/vision.py
+++ b/vision.py
@@ -5,8 +5,11 @@ import cv2
 MIN_MASKED_RATIO = 0.1
 
 
-def vision_loop(data_array):
+def loop():
     import cscore as cs
+    from networktables import NetworkTables
+
+    nt = NetworkTables.getTable("/components/vision")
 
     width = 320
     height = 240
@@ -42,8 +45,8 @@ def vision_loop(data_array):
             if masked_ratio > MIN_MASKED_RATIO:
                 loc = int((x+1) * width // 2)
                 cv2.line(img, (loc, 60), (loc, 180), (255, 255, 0), thickness=2, lineType=8, shift=0)
-                data_array[0] = x
-                data_array[1] = time
+                nt.putNumber("x", x)
+                nt.putNumber("time", time)
             cvSource.putFrame(img)
 
 

--- a/vision.py
+++ b/vision.py
@@ -1,0 +1,71 @@
+import numpy as np
+import cv2
+
+
+MIN_MASKED_RATIO = 0.1
+
+
+def vision_loop(data_array):
+    import cscore as cs
+
+    width = 320
+    height = 240
+    fps = 25
+    videomode = cs.VideoMode.PixelFormat.kMJPEG, width, height, fps
+
+    camera = cs.UsbCamera("usbcam", 0)
+    camera.setVideoMode(*videomode)
+
+    camMjpegServer = cs.MjpegServer("httpserver", 8082)
+    camMjpegServer.setSource(camera)
+
+    cvsink = cs.CvSink("cvsink")
+    cvsink.setSource(camera)
+
+    cvSource = cs.CvSource("cvsource", *videomode)
+    cvmjpegServer = cs.MjpegServer("cvhttpserver", 8083)
+    cvmjpegServer.setSource(cvSource)
+
+    #Setting the exposure.
+    camera.setExposureManual(0)
+
+    # Images are big. Preallocate an array to fill the image with.
+    frame = np.zeros(shape=(height, width, 3), dtype=np.uint8)
+
+    while True:
+        time, frame = cvsink.grabFrame(frame)
+        if time == 0:
+            # We got an error; report it through the output stream.
+            cvSource.notifyError(cvsink.getError())
+        else:
+            x, img, masked_ratio = find_target(frame)
+            if masked_ratio > MIN_MASKED_RATIO:
+                loc = int((x+1) * width // 2)
+                cv2.line(img, (loc, 60), (loc, 180), (255, 255, 0), thickness=2, lineType=8, shift=0)
+                data_array[0] = x
+                data_array[1] = time
+            cvSource.putFrame(img)
+
+
+def find_target(img, lower=np.array([110/2, 200, 75]), upper=np.array([155/2, 255, 255])):
+    #Converting from RGB to HSV.
+    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+
+    #Making the mask.
+    mask = cv2.inRange(hsv, lower, upper)
+
+    #Combining the mask with the frame
+    res = cv2.bitwise_and(img, img, mask=mask)
+
+    height, width = mask.shape
+    masked_pixels = mask.sum()
+    masked_ratio = masked_pixels / (height*width)
+
+    if masked_ratio > MIN_MASKED_RATIO:
+        X, Y = np.meshgrid(range(0, width), range(0, height))
+        x_coord = int((X * mask).sum() / masked_pixels)
+    else:
+        return None, res, masked_ratio
+
+    pos = 2 * x_coord / width - 1
+    return pos, res, masked_ratio

--- a/vision.py
+++ b/vision.py
@@ -51,6 +51,11 @@ def loop():
 
 
 def find_target(img, lower=np.array([110/2, 200, 75]), upper=np.array([155/2, 255, 255])):
+    """Given an image and thresholds, find the centre of mass of the target.
+
+    All arguments must be np.arrays, and lower and upper must be a 3-array.
+    """
+
     #Converting from RGB to HSV.
     hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
 


### PR DESCRIPTION
This separates the vision loop into its own module and uses NetworkTables for IPC.

This also documents the tunables used in the vision component and the `find_target` function, and allows for running the vision loop manually on a PC.

The now redundant `vision_x` SmartDashboard values have been removed from the manipulategear component — this will need to be changed on the dashboard as well.